### PR TITLE
Add libjpeg vs libjpegturbo benchmark

### DIFF
--- a/src/camera/camera.h
+++ b/src/camera/camera.h
@@ -33,5 +33,6 @@ class ICamera {
   [[nodiscard]] virtual auto GetCameraConstant() const -> camera_constant_t = 0;
   virtual auto IsDone() -> bool { return false; }
   virtual ~ICamera() = default;
+  virtual void Grab() = 0;
 };
 }  // namespace camera

--- a/src/camera/cv_camera.cc
+++ b/src/camera/cv_camera.cc
@@ -66,10 +66,6 @@ CVCamera::CVCamera(const CameraConstant& c, std::optional<std::string> log_path)
 auto CVCamera::GetFrame() -> timestamped_frame_t {
   timestamped_frame_t timestamped_frame;
   cv::Mat raw_image;
-  if (!cap_.grab()) {
-    Restart();
-    LOG(WARNING) << "Restarting camera";
-  }
   timestamped_frame.timestamp = frc::Timer::GetFPGATimestamp().to<double>();
   cap_.retrieve(raw_image);
 
@@ -94,6 +90,13 @@ auto CVCamera::Restart() -> void {
   LOG(INFO) << "Restarting camera with pipeline: " << pipeline_;
   cap_ = cv::VideoCapture(pipeline_);
   std::this_thread::sleep_for(std::chrono::seconds(3));
+}
+
+auto CVCamera::Grab() -> void {
+  if (!cap_.grab()) {
+    Restart();
+    LOG(WARNING) << "Restarting camera";
+  cap_timestamp_ = frc::Timer::GetFPGATimestamp().to<double>();
 }
 
 auto CVCamera::GetCameraConstant() const -> camera_constant_t {

--- a/src/camera/cv_camera.h
+++ b/src/camera/cv_camera.h
@@ -13,6 +13,7 @@ class CVCamera : public ICamera {
            std::optional<std::string> log_path = std::nullopt);
   auto GetFrame() -> timestamped_frame_t override;
   auto Restart() -> void override;
+  auto Grab() -> void override;
   [[nodiscard]] auto GetCameraConstant() const -> camera_constant_t override;
 
  private:
@@ -21,6 +22,7 @@ class CVCamera : public ICamera {
   std::string pipeline_;
   std::optional<std::string> log_path_;
   cv::Mat backup_image_;
+  double cap_timestamp_;
 };
 
 }  // namespace camera

--- a/src/camera/disk_camera.cc
+++ b/src/camera/disk_camera.cc
@@ -80,6 +80,8 @@ auto DiskCamera::GetFrame() -> timestamped_frame_t {
 
 auto DiskCamera::Restart() -> void {}
 
+auto DiskCamera::Grab() -> void {}
+
 auto DiskCamera::GetCameraConstant() const -> camera_constant_t {
   return *camera_constant_;
 }

--- a/src/camera/disk_camera.h
+++ b/src/camera/disk_camera.h
@@ -31,6 +31,7 @@ class DiskCamera : public ICamera {
              std::optional<double> end = std::nullopt);
   auto GetFrame() -> timestamped_frame_t override;
   auto Restart() -> void override;
+  auto Grab() -> void override;
   auto IsDone() -> bool override { return image_paths_.empty(); }
   [[nodiscard]] auto GetCameraConstant() const -> camera_constant_t override;
 

--- a/src/test/integration_test/CMakeLists.txt
+++ b/src/test/integration_test/CMakeLists.txt
@@ -30,3 +30,6 @@ target_link_libraries(pva_test PRIVATE utils localization vpi)
 
 add_executable(bfs-test bfs_tester.cc)
 target_link_libraries(bfs-test PRIVATE pathing utils nlohmann_json::nlohmann_json wpiutil)
+
+add_executable(libjpeg-benchmark libjpeg_benchmark.cc)
+target_link_libraries(libjpeg-benchmark PRIVATE ${OpenCV_LIBS} utils)

--- a/src/test/integration_test/libjpeg_benchmark.cc
+++ b/src/test/integration_test/libjpeg_benchmark.cc
@@ -6,6 +6,7 @@
 #include "absl/flags/parse.h"
 #include "src/utils/log.h"
 #include "src/utils/pch.h"
+#include <sstream>
 
 ABSL_FLAG(std::string, image_path, "path/to/image.jpg",  // NOLINT
           "Path to the image file to be loaded and decoded.");

--- a/src/test/integration_test/libjpeg_benchmark.cc
+++ b/src/test/integration_test/libjpeg_benchmark.cc
@@ -1,0 +1,49 @@
+#include "src/utils/pch.h"
+#include "src/utils/log.h"
+#include "absl/flags/flag.h"
+#include "absl/flags/internal/flag.h"
+#include "absl/flags/parse.h"
+
+ABSL_FLAG(std::string, image_path, "path/to/image.jpg", "Path to the image file to be loaded and decoded.");
+
+auto loadImage(std::string path) -> std::vector<uchar> {
+  std::ifstream file(path, std::ios::binary);
+  if (!file) {
+    LOG(FATAL) << "Image could not be loaded; path invalid or image doesn't exist.";
+  }
+  std::vector<uchar> data(std::istreambuf_iterator<char>(file), {});
+  return data;
+}
+
+auto decodeImage(std::vector<uchar> raw) -> cv::Mat {
+  cv::Mat decoded = cv::imdecode(raw, cv::IMREAD_COLOR);
+  return decoded;
+}
+
+auto main(int argc, char** argv) -> int {
+  absl::ParseCommandLine(argc, argv);
+  std::string imagePath = absl::GetFlag(FLAGS_image_path);
+  std::vector<uchar> rawImageData = loadImage(imagePath);
+  // print which jpeg library we are using so that we know and don't get mixed up
+  std::istringstream stream(cv::getBuildInformation());
+  std::string line;
+  while (std::getline(stream, line)) {
+      if (line.find("jpeg:") != std::string::npos || line.find("JPEG:") != std::string::npos) {
+          LOG(INFO) << line;
+      }
+  }
+  const uint tests = 1000;
+  std::vector<double> trials;
+  for (uint i = 0; i < tests; ++i) {
+    auto start = std::chrono::high_resolution_clock::now();
+    cv::Mat decodedImage = decodeImage(rawImageData);
+    auto end = std::chrono::high_resolution_clock::now();
+    double ms = std::chrono::duration<double, std::milli>(end - start).count();
+    trials.push_back(ms);
+  }
+
+  double total = std::accumulate(trials.begin(), trials.end(), 0.0);
+  double average = total / trials.size();
+  LOG(INFO) << "Average decoding time over " << tests << " trials: " << average << " ms";
+  return 0;
+}

--- a/src/test/integration_test/libjpeg_benchmark.cc
+++ b/src/test/integration_test/libjpeg_benchmark.cc
@@ -44,6 +44,10 @@ auto main(int argc, char** argv) -> int {
     auto start = std::chrono::high_resolution_clock::now();
     cv::Mat decodedImage = decodeImage(rawImageData);
     auto end = std::chrono::high_resolution_clock::now();
+    if (decodedImage.empty()) {
+      LOG(INFO) << "image decode failed";
+      continue;
+    }
     double ms = std::chrono::duration<double, std::milli>(end - start).count();
     trials.push_back(ms);
   }

--- a/src/test/integration_test/libjpeg_benchmark.cc
+++ b/src/test/integration_test/libjpeg_benchmark.cc
@@ -1,21 +1,26 @@
-#include "src/utils/pch.h"
-#include "src/utils/log.h"
+#include <chrono>
+#include <iterator>
+#include <numeric>
 #include "absl/flags/flag.h"
 #include "absl/flags/internal/flag.h"
 #include "absl/flags/parse.h"
+#include "src/utils/log.h"
+#include "src/utils/pch.h"
 
-ABSL_FLAG(std::string, image_path, "path/to/image.jpg", "Path to the image file to be loaded and decoded.");
+ABSL_FLAG(std::string, image_path, "path/to/image.jpg",  // NOLINT
+          "Path to the image file to be loaded and decoded.");
 
-auto loadImage(std::string path) -> std::vector<uchar> {
+auto loadImage(const std::string& path) -> std::vector<uchar> {
   std::ifstream file(path, std::ios::binary);
   if (!file) {
-    LOG(FATAL) << "Image could not be loaded; path invalid or image doesn't exist.";
+    LOG(FATAL) << "Image could not be loaded from path '" << path
+               << "'; path invalid or image doesn't exist.";
   }
   std::vector<uchar> data(std::istreambuf_iterator<char>(file), {});
   return data;
 }
 
-auto decodeImage(std::vector<uchar> raw) -> cv::Mat {
+auto decodeImage(const std::vector<uchar>& raw) -> cv::Mat {
   cv::Mat decoded = cv::imdecode(raw, cv::IMREAD_COLOR);
   return decoded;
 }
@@ -28,9 +33,10 @@ auto main(int argc, char** argv) -> int {
   std::istringstream stream(cv::getBuildInformation());
   std::string line;
   while (std::getline(stream, line)) {
-      if (line.find("jpeg:") != std::string::npos || line.find("JPEG:") != std::string::npos) {
-          LOG(INFO) << line;
-      }
+    if (line.find("jpeg:") != std::string::npos ||
+        line.find("JPEG:") != std::string::npos) {
+      LOG(INFO) << line;
+    }
   }
   const uint tests = 1000;
   std::vector<double> trials;
@@ -44,6 +50,7 @@ auto main(int argc, char** argv) -> int {
 
   double total = std::accumulate(trials.begin(), trials.end(), 0.0);
   double average = total / trials.size();
-  LOG(INFO) << "Average decoding time over " << tests << " trials: " << average << " ms";
+  LOG(INFO) << "Average decoding time over " << tests << " trials: " << average
+            << " ms";
   return 0;
 }

--- a/src/test/integration_test/libjpeg_benchmark.cc
+++ b/src/test/integration_test/libjpeg_benchmark.cc
@@ -11,6 +11,8 @@
 ABSL_FLAG(std::string, image_path, "path/to/image.jpg",  // NOLINT
           "Path to the image file to be loaded and decoded.");
 
+ABSL_FLAG(uint, num_trials, 10000, "Number of decoding trials to perform."); // NOLINT
+
 auto loadImage(const std::string& path) -> std::vector<uchar> {
   std::ifstream file(path, std::ios::binary);
   if (!file) {
@@ -39,7 +41,7 @@ auto main(int argc, char** argv) -> int {
       LOG(INFO) << line;
     }
   }
-  const uint tests = 1000;
+  const uint tests = absl::GetFlag(FLAGS_num_trials);
   std::vector<double> trials;
   for (uint i = 0; i < tests; ++i) {
     auto start = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION

## Regular libjpeg
```
I0000 00:00:1777418994.528245 1743938 libjpeg_benchmark.cc:39]     JPEG: /usr/lib/aarch64-linux-gnu/libjpeg.so (ver 80)
0000 00:00:1777419114.247866 1743938 libjpeg_benchmark.cc:58] Average decoding time over 10000 trials: 11.9704 ms 
``` 

## libjpegturbo
```
I0000 00:00:1777425703.420417 1762632 libjpeg_benchmark.cc:41]     JPEG: /usr/lib/aarch64-linux-gnu/libjpeg.so (ver 80)
I0000 00:00:1777425822.867357 1762632 libjpeg_benchmark.cc:60] Average decoding time over 10000 trials: 11.943 ms
```